### PR TITLE
INFO fields renamed in redis server >= 2.6

### DIFF
--- a/spec/redis_commands_spec.rb
+++ b/spec/redis_commands_spec.rb
@@ -560,7 +560,7 @@ EM.describe EM::Protocols::Redis do
   #
   it "should provide info (INFO)" do
     @r.info do |r|
-      [:last_save_time, :redis_version, :total_connections_received, :connected_clients, :total_commands_processed, :connected_slaves, :uptime_in_seconds, :used_memory, :uptime_in_days, :changes_since_last_save].each do |x|
+      [:rdb_last_save_time, :redis_version, :total_connections_received, :connected_clients, :total_commands_processed, :connected_slaves, :uptime_in_seconds, :used_memory, :uptime_in_days, :rdb_changes_since_last_save].each do |x|
         r.keys.include?(x).should == true
       end
       done


### PR DESCRIPTION
Some of the INFO fields have been renamed in recent versions of the redis server, and have now a rdb_ prefix. Adapting the specs to reflect that.

See https://raw.github.com/antirez/redis/2.6/00-RELEASENOTES.

With this changes, the tests pass with redis-server 2.8.
